### PR TITLE
Patch swipebox for compatibility with jQuery 3

### DIFF
--- a/wordpress/plugins/pigg/pigg.php
+++ b/wordpress/plugins/pigg/pigg.php
@@ -23,7 +23,7 @@ $pig_template = <<<HTML
       <img id='gsPreviewImg'>
     </div>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.swipebox/1.4.4/css/swipebox.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.swipebox/1.4.4/js/jquery.swipebox.min.js"></script>
+    <script src="https://i.modjeska.us/js/jquery.swipebox.min.js"></script>
     <script type="text/javascript" src="https://raw.githubusercontent.com/jmodjeska/pigg/master/js/pig.js"></script>
     <script type="text/javascript">
       var imageData = [


### PR DESCRIPTION
Use a patched version of swipebox.js that is compatible with jQuery 3.x.x.

Patched version from @mho79 (thank you!)

Discussion: https://wordpress.org/support/topic/website-goes-blank-swipebox-overlay/
